### PR TITLE
Update version constants

### DIFF
--- a/src/staticglfw.nim
+++ b/src/staticglfw.nim
@@ -89,8 +89,8 @@ else:
 
 const
   VERSION_MAJOR* = 3
-  VERSION_MINOR* = 2
-  VERSION_REVISION* = 0
+  VERSION_MINOR* = 3
+  VERSION_REVISION* = 2
 
   TRUE* = 1
   FALSE* = 0


### PR DESCRIPTION
Version constants should now be consistent with the GLFW version being used:

![image](https://user-images.githubusercontent.com/10100000/119579835-44f6de80-bd8d-11eb-8a66-f5c3060b187c.png)
