### PR TITLE
Fix wayland compilation by generating wayland protocol files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ nimcache
 *.pdb
 *.ilk
 .*
+
+# generated wayland protocol source files
+wayland-*-protocol.c
+wayland-*-protocol.h


### PR DESCRIPTION
Some wayland specific headers and files were not generated, preventing compilation with `-d:wayland`. See https://forum.nim-lang.org/t/9476#62256 for context. 
They are now generated at compile time with `wayland-scanner`, like `glfw` cmake build does. Moreover `libwayland-client` is linked.